### PR TITLE
update carbonblack pipeline so it can be run alone

### DIFF
--- a/sigma/pipelines/panther/carbon_black_panther_pipeline.py
+++ b/sigma/pipelines/panther/carbon_black_panther_pipeline.py
@@ -15,6 +15,8 @@ from sigma.pipelines.panther.panther_sdyaml_pipeline import (
     logsource_windows,
 )
 
+from sigma.pipelines.panther.sdyaml_transformation import SdYamlTransformation
+
 
 def carbon_black_panther_pipeline():
     return ProcessingPipeline(
@@ -63,5 +65,8 @@ def carbon_black_panther_pipeline():
                 transformation=DropDetectionItemTransformation(),
                 field_name_conditions=[IncludeFieldCondition(fields=["OriginalFileName"])],
             ),
+        ],
+        postprocessing_items=[
+            SdYamlTransformation(),
         ],
     )

--- a/sigma/pipelines/panther/carbon_black_panther_pipeline.py
+++ b/sigma/pipelines/panther/carbon_black_panther_pipeline.py
@@ -14,7 +14,6 @@ from sigma.pipelines.panther.panther_sdyaml_pipeline import (
     logsource_process_creation,
     logsource_windows,
 )
-
 from sigma.pipelines.panther.sdyaml_transformation import SdYamlTransformation
 
 

--- a/sigma/pipelines/panther/panther_sdyaml_pipeline.py
+++ b/sigma/pipelines/panther/panther_sdyaml_pipeline.py
@@ -86,6 +86,7 @@ def panther_sdyaml_pipeline():
                 ),
                 rule_conditions=[
                     logsource_windows(),
+                    crowdstrike_pipeline_was_used(),
                 ],
             ),
             ProcessingItem(
@@ -121,7 +122,7 @@ def panther_sdyaml_pipeline():
                         "event_simpleName": "FileOpenInfo",
                     }
                 ),
-                rule_conditions=[logsource_file_event()],
+                rule_conditions=[logsource_file_event(), crowdstrike_pipeline_was_used()],
             ),
             ProcessingItem(
                 transformation=AddConditionTransformation(
@@ -134,7 +135,7 @@ def panther_sdyaml_pipeline():
                         ],
                     }
                 ),
-                rule_conditions=[logsource_network_connection()],
+                rule_conditions=[logsource_network_connection(), crowdstrike_pipeline_was_used()],
             ),
             ProcessingItem(
                 transformation=FieldMappingTransformation(

--- a/tests/test_carbon_black_panther_pipeline.py
+++ b/tests/test_carbon_black_panther_pipeline.py
@@ -18,6 +18,7 @@ def test_basic():
         f"""
         title: Test Title
         id: {rule_id}
+        description: description
         logsource:
             category: process_creation
             product: macos
@@ -31,36 +32,45 @@ def test_basic():
 
     expected = yaml.dump(
         {
-            "All": [
-                {
-                    "Condition": "Equals",
-                    "KeyPath": "type",
-                    "Value": "endpoint.event.procstart",
-                },
+            "Description": "description",
+            "AnalysisType": "rule",
+            "DisplayName": "Test Title",
+            "Enabled": True,
+            "Tags": [],
+            "Detection": [
                 {
                     "All": [
                         {
                             "Condition": "Equals",
-                            "KeyPath": "device_os",
-                            "Value": "MAC",
+                            "KeyPath": "type",
+                            "Value": "endpoint.event.procstart",
                         },
                         {
                             "All": [
                                 {
                                     "Condition": "Equals",
-                                    "KeyPath": "Field1",
-                                    "Value": "banana",
+                                    "KeyPath": "device_os",
+                                    "Value": "MAC",
                                 },
                                 {
-                                    "Condition": "Equals",
-                                    "KeyPath": "remote_ip",
-                                    "Value": "127.0.0.1",
+                                    "All": [
+                                        {
+                                            "Condition": "Equals",
+                                            "KeyPath": "Field1",
+                                            "Value": "banana",
+                                        },
+                                        {
+                                            "Condition": "Equals",
+                                            "KeyPath": "remote_ip",
+                                            "Value": "127.0.0.1",
+                                        },
+                                    ]
                                 },
                             ]
                         },
                     ]
-                },
-            ]
+                }
+            ],
         }
     )
 

--- a/tests/test_panther_sdyaml_pipeline.py
+++ b/tests/test_panther_sdyaml_pipeline.py
@@ -28,18 +28,9 @@ def test_basic(sigma_sdyaml_backend):
             "Enabled": True,
             "Detection": [
                 {
-                    "All": [
-                        {
-                            "Condition": "Equals",
-                            "KeyPath": "event_simpleName",
-                            "Value": "ProcessRollup2",
-                        },
-                        {
-                            "Condition": "Equals",
-                            "KeyPath": "Field1",
-                            "Value": "banana",
-                        },
-                    ]
+                    "Condition": "Equals",
+                    "KeyPath": "Field1",
+                    "Value": "banana",
                 },
             ],
         }

--- a/tests/test_replace_condition_ends_with.py
+++ b/tests/test_replace_condition_ends_with.py
@@ -25,10 +25,6 @@ class TestReplaceConditionEndsWith:
         AnalysisType: rule
         Description: null
         Detection:
-        - All:
-          - Condition: Equals
-            KeyPath: event_simpleName
-            Value: ProcessRollup2
           - Condition: EndsWith
             KeyPath: UpdatedField
             Value: banana
@@ -64,10 +60,6 @@ class TestReplaceConditionEndsWith:
         AnalysisType: rule
         Description: null
         Detection:
-        - All:
-          - Condition: Equals
-            KeyPath: event_simpleName
-            Value: ProcessRollup2
           - Any:
               - Condition: EndsWith
                 KeyPath: UpdatedField
@@ -112,10 +104,6 @@ class TestReplaceConditionEndsWith:
         AnalysisType: rule
         Description: null
         Detection:
-          - All:
-            - Condition: Equals
-              KeyPath: event_simpleName
-              Value: ProcessRollup2
             - All:
               - Condition: EndsWith
                 KeyPath: ReplacedFileName


### PR DESCRIPTION
This PR updates Carbon Black pipeline so it can be run without the sdyaml pipeline, for exmaple:

`sigma convert -t panther_sdyaml -p carbon_black_panther ../sigma/rules/windows/network_connection/net_connection_win_notepad_network_connection.yml`

Instead of `sigma convert -t panther_sdyaml -p panther_sdyaml -p carbon_black_panther ../sigma/rules/windows/network_connection/net_connection_win_notepad_network_connection.yml` which results in buggy behavior where the resulting sdyaml rule gets log category mappings from both CrowdStrike and Carbon Black:

```Detection:
- All:
  - Condition: Equals
    KeyPath: type
    Value: endpoint.event.netconn
  - All:
    - Condition: Equals
      KeyPath: device_os
      Value: WINDOWS
    - All:
      - Condition: IsIn
        KeyPath: event_simpleName
        Values:
        - NetworkConnectIP4
        - NetworkConnectIP6
        - NetworkReceiveAcceptIP4
        - NetworkReceiveAcceptIP6
      - All:
        - Condition: Equals
          KeyPath: event_simpleName
          Value: ProcessRollup2```