### PR TITLE
Add pipeline prefixes to converted rules/files

### DIFF
--- a/sigma/pipelines/panther/crowdstrike_panther_pipeline.py
+++ b/sigma/pipelines/panther/crowdstrike_panther_pipeline.py
@@ -1,5 +1,5 @@
 from sigma.pipelines.crowdstrike import crowdstrike_fdr_pipeline
-from sigma.processing.conditions import IncludeFieldCondition, RuleContainsDetectionItemCondition
+from sigma.processing.conditions import IncludeFieldCondition
 from sigma.processing.pipeline import ProcessingItem
 from sigma.processing.transformations import (
     AddConditionTransformation,

--- a/sigma/pipelines/panther/processing.py
+++ b/sigma/pipelines/panther/processing.py
@@ -5,7 +5,7 @@ from sigma.rule import SigmaDetection, SigmaDetectionItem
 
 
 class RuleIContainsDetectionItemCondition(RuleContainsDetectionItemCondition):
-    # same as RuleContainsDetectionItemCondition, but case insensitive
+    # same as RuleContainsDetectionItemCondition, but case-insensitive
     def find_detection_item(self, detection: Union[SigmaDetectionItem, SigmaDetection]) -> bool:
         if isinstance(detection, SigmaDetection):
             for detection_item in detection.detection_items:


### PR DESCRIPTION
There may be some scenarios where multiple EDRs are in use in the same Panther instance.  Add EDR prefixes to the generated filename and RuleID to avoid conflicts.

CrowdStrike: cs_

Carbon Black: cb_

SentinelOne: s1_