### PR TITLE
Renamed panther_sdyaml backend to panther and added sdyaml as formatt…

### DIFF
--- a/sigma/backends/panther/__init__.py
+++ b/sigma/backends/panther/__init__.py
@@ -1,7 +1,7 @@
-from .panther_sdyaml_backend import PantherSdyamlBackend
+from .panther_backend import PantherBackend
 
 # TODO: add all backend classes that should be exposed to the user of your backend in the import statement above.
 
 backends = {  # Mapping between backend identifiers and classes. This is used by the pySigma plugin system to recognize backends and expose them with the identifier.
-    "panther_sdyaml": PantherSdyamlBackend,
+    "panther": PantherBackend,
 }

--- a/sigma/backends/panther/panther_backend.py
+++ b/sigma/backends/panther/panther_backend.py
@@ -25,12 +25,22 @@ from sigma.rule import SigmaRule
 from sigma.types import SigmaString, SpecialChars
 
 
-class PantherSdyamlBackend(Backend):
+class PantherBackend(Backend):
     # `output_dir` param should be used for saving each rule into separate file
     # `sigma convert -t panther_sdyaml -O output_dir=/tmp/directory`
     output_dir: Optional[str] = None
 
     name: ClassVar[str] = "panther sdyaml backend"
+
+    default_format: ClassVar[str] = "sdyaml"
+    formats = {
+        "default": "sdyaml",
+        "sdyaml": "sdyaml",
+    }
+    output_format_processing_pipeline = {
+        "default": ProcessingPipeline(),
+        "sdyaml": ProcessingPipeline(),
+    }
 
     convert_or_as_in: ClassVar[bool] = True
     convert_and_as_in: ClassVar[bool] = True
@@ -446,6 +456,9 @@ class PantherSdyamlBackend(Backend):
                 yaml.dump(query, file)
 
     def finalize_output_default(self, queries: List[Any]) -> Any:
+        return self.finalize_output_sdyaml(queries)
+
+    def finalize_output_sdyaml(self, queries):
         if self.output_dir:
             self.save_queries_into_individual_files(queries)
         # cleanup of SigmaFile key
@@ -454,3 +467,8 @@ class PantherSdyamlBackend(Backend):
         if len(queries) == 1:
             return yaml.dump(queries[0])
         return yaml.dump(queries)
+
+    def finalize_query_sdyaml(
+        self, rule: SigmaRule, query: Any, index: int, state: ConversionState
+    ):
+        return query

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ from sigma.rule import (
     SigmaLogSource,
     SigmaRule,
 )
-from sigma.types import SigmaNull, SigmaType
+from sigma.types import SigmaNull
 
-from sigma.backends.panther import PantherSdyamlBackend
+from sigma.backends.panther import PantherBackend
 from sigma.pipelines.panther.panther_sdyaml_pipeline import panther_sdyaml_pipeline
 
 
@@ -18,7 +18,7 @@ from sigma.pipelines.panther.panther_sdyaml_pipeline import panther_sdyaml_pipel
 def sigma_sdyaml_backend():
     resolver = ProcessingPipelineResolver({"panther_sdyaml": panther_sdyaml_pipeline})
     pipeline = resolver.resolve_pipeline("panther_sdyaml")
-    backend = PantherSdyamlBackend(pipeline)
+    backend = PantherBackend(pipeline)
     return backend
 
 

--- a/tests/test_carbon_black_panther_pipeline.py
+++ b/tests/test_carbon_black_panther_pipeline.py
@@ -4,14 +4,14 @@ import yaml
 from sigma.collection import SigmaCollection
 from sigma.processing.resolver import ProcessingPipelineResolver
 
-from sigma.backends.panther import PantherSdyamlBackend
+from sigma.backends.panther import PantherBackend
 from sigma.pipelines.panther import carbon_black_panther_pipeline
 
 
 def test_basic():
     resolver = ProcessingPipelineResolver({"carbon_black_panther": carbon_black_panther_pipeline()})
     pipeline = resolver.resolve_pipeline("carbon_black_panther")
-    backend = PantherSdyamlBackend(pipeline)
+    backend = PantherBackend(pipeline)
 
     rule_id = uuid.uuid4()
     rule = SigmaCollection.from_yaml(

--- a/tests/test_crowdstrike_panther_pipeline.py
+++ b/tests/test_crowdstrike_panther_pipeline.py
@@ -4,14 +4,14 @@ import yaml
 from sigma.collection import SigmaCollection
 from sigma.processing.resolver import ProcessingPipelineResolver
 
-from sigma.backends.panther import PantherSdyamlBackend
+from sigma.backends.panther import PantherBackend
 from sigma.pipelines.panther import crowdstrike_panther_pipeline
 
 
 def test_basic():
     resolver = ProcessingPipelineResolver({"crowdstrike_panther": crowdstrike_panther_pipeline()})
     pipeline = resolver.resolve_pipeline("crowdstrike_panther")
-    backend = PantherSdyamlBackend(pipeline)
+    backend = PantherBackend(pipeline)
 
     rule_id = uuid.uuid4()
     rule = SigmaCollection.from_yaml(

--- a/tests/test_panther_sdyaml_backend.py
+++ b/tests/test_panther_sdyaml_backend.py
@@ -6,7 +6,7 @@ import yaml
 from sigma.collection import SigmaCollection
 from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 
-from sigma.backends.panther import PantherSdyamlBackend
+from sigma.backends.panther import PantherBackend
 
 
 def assert_yaml_equal(actual, expected):
@@ -14,12 +14,12 @@ def assert_yaml_equal(actual, expected):
 
 
 def convert_rule(rule):
-    return PantherSdyamlBackend().convert(SigmaCollection.from_yaml(sigma_query(rule)))
+    return PantherBackend().convert(SigmaCollection.from_yaml(sigma_query(rule)))
 
 
 @pytest.fixture
 def backend():
-    return PantherSdyamlBackend()
+    return PantherBackend()
 
 
 def sigma_query(detection):


### PR DESCRIPTION
Adds `sdyaml` as formatting option to be able to output rules in various formats. This is essential for being able to convert sigma rules to panther python rules.
Example: `sigma convert -t panther -f sdyaml -p logsource`