### PR TITLE
Fix ParentBaseFileName field name error

### DIFF
--- a/sigma/pipelines/panther/crowdstrike_panther_pipeline.py
+++ b/sigma/pipelines/panther/crowdstrike_panther_pipeline.py
@@ -4,12 +4,11 @@ from sigma.pipelines.common import (
     logsource_windows_network_connection_initiated,
     logsource_windows_process_creation,
 )
-from sigma.processing.conditions import IncludeFieldCondition, MatchStringCondition
+from sigma.processing.conditions import IncludeFieldCondition
 from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
 from sigma.processing.transformations import (
     AddConditionTransformation,
     ChangeLogsourceTransformation,
-    DetectionItemFailureTransformation,
     DropDetectionItemTransformation,
     FieldMappingTransformation,
     ReplaceStringTransformation,
@@ -159,27 +158,10 @@ def crowdstrike_panther_pipeline():
                     logsource_windows_dns_query(),
                 ],
             ),
-            # ParentBaseFileName handling
-            ProcessingItem(
-                identifier="cs_parentbasefilename_fail_completepath",
-                transformation=DetectionItemFailureTransformation(
-                    "Only file name of parent image is available in CrowdStrike events."
-                ),
-                field_name_conditions=[
-                    IncludeFieldCondition(fields=["ParentBaseFileName"]),
-                ],
-                detection_item_conditions=[
-                    MatchStringCondition(
-                        cond="any",
-                        pattern="^\\*\\\\?[^\\\\]+$",
-                        negate=True,
-                    )
-                ],
-            ),
             ProcessingItem(
                 identifier="cs_parentbasefilename_executable_only",
                 transformation=ReplaceStringTransformation(
-                    regex="^\\*\\\\([^\\\\]+)$",
+                    regex=".*\\\\(.+)$",
                     replacement="\\1",
                 ),
                 field_name_conditions=[

--- a/tests/test_crowdstrike_panther_pipeline.py
+++ b/tests/test_crowdstrike_panther_pipeline.py
@@ -21,12 +21,13 @@ def test_basic():
         description: description
         logsource:
             category: process_creation
-            product: macos
+            product: windows
         detection:
             sel:
                 Field1: "banana"
                 DestinationIp: 127.0.0.1
                 Initiated: "true"
+                ParentImage: C:\\Program Files\\Microsoft Monitoring Agent\\Agent\\MonitoringHost.exe
             condition: sel
     """
     )
@@ -44,7 +45,12 @@ def test_basic():
                         {
                             "Condition": "Equals",
                             "KeyPath": "event_platform",
-                            "Value": "Mac",
+                            "Value": "Windows",
+                        },
+                        {
+                            "Condition": "IsIn",
+                            "KeyPath": "event_simpleName",
+                            "Values": ["ProcessRollup2", "SyntheticProcessRollup2"],
                         },
                         {
                             "Condition": "Equals",
@@ -60,6 +66,11 @@ def test_basic():
                             "Condition": "Equals",
                             "KeyPath": "Initiated",
                             "Value": "true",
+                        },
+                        {
+                            "Condition": "Equals",
+                            "KeyPath": "ParentBaseFileName",
+                            "Value": "MonitoringHost.exe",
                         },
                     ]
                 }


### PR DESCRIPTION
Fixes `Only file name of parent image is available in CrowdStrike events. ` error