### PR TITLE
Remove `any` and `all` when only 1 condition

### DIFF
--- a/sigma/backends/panther/helpers/base.py
+++ b/sigma/backends/panther/helpers/base.py
@@ -6,7 +6,6 @@ import click
 from sigma.conditions import (
     ConditionAND,
     ConditionFieldEqualsValueExpression,
-    ConditionNOT,
     ConditionOR,
     ParentChainMixin,
 )

--- a/sigma/backends/panther/panther_backend.py
+++ b/sigma/backends/panther/panther_backend.py
@@ -6,11 +6,9 @@ import yaml
 from sigma.conditions import (
     ConditionAND,
     ConditionFieldEqualsValueExpression,
-    ConditionItem,
     ConditionNOT,
     ConditionOR,
     ConditionValueExpression,
-    ParentChainMixin,
 )
 from sigma.conversion.base import Backend
 from sigma.conversion.state import ConversionState


### PR DESCRIPTION
Update for cases when the pipeline drops a field and it results in an any() clause with only 1 element