### PR TITLE
Rename panther_sdyaml pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ It supports the following output formats:
 * python (`-f python`): [Panther Python Detections](https://docs.panther.com/detections/rules/python)
 
 To save each rule in separate file you can use `output_dir` backend option.
-> $ sigma convert -t panther -f sdyaml path/to/rules -p panther_sdyaml -O output_dir=output/directory
+> $ sigma convert -t panther -f sdyaml path/to/rules -p panther -O output_dir=output/directory
 or
-> $ sigma convert -t panther -f python path/to/rules -p panther_sdyaml -O output_dir=output/directory
+> $ sigma convert -t panther -f python path/to/rules -p panther -O output_dir=output/directory
 
-Further, it contains the following processing pipelines in `sigma.pipelines.panther_sdyaml`:
+Further, it contains the following processing pipelines in `sigma.pipelines.panther`:
 
-* panther_sdyaml_pipeline: Convert known Sigma field names into their Panther schema equivalent
+* panther_pipeline: Convert known Sigma field names into their Panther schema equivalent
 
 ### Local setup for development
 Clone this repo, cd into it and run:
@@ -30,7 +30,7 @@ Now you can run tests with:
 ```poetry run pytest```
 
 To convert rules to panther sdyaml format run:
-```poetry run sigma convert -t panther -f sdyaml -p panther_sdyaml path_to_sigma_rule.yml```
+```poetry run sigma convert -t panther -f sdyaml -p panther path_to_sigma_rule.yml```
 
 This backend is currently maintained by:
 

--- a/sigma/pipelines/panther/__init__.py
+++ b/sigma/pipelines/panther/__init__.py
@@ -1,4 +1,4 @@
 from .carbon_black_panther_pipeline import carbon_black_panther_pipeline
 from .crowdstrike_panther_pipeline import crowdstrike_panther_pipeline
 from .gcp_audit_panther_pipeline import gcp_audit_panther_pipeline
-from .panther_sdyaml_pipeline import panther_sdyaml_pipeline
+from .panther_pipeline import panther_pipeline

--- a/sigma/pipelines/panther/carbon_black_panther_pipeline.py
+++ b/sigma/pipelines/panther/carbon_black_panther_pipeline.py
@@ -6,7 +6,7 @@ from sigma.processing.transformations import (
     FieldMappingTransformation,
 )
 
-from sigma.pipelines.panther.panther_sdyaml_pipeline import (
+from sigma.pipelines.panther.panther_pipeline import (
     logsource_file_event,
     logsource_linux,
     logsource_mac,

--- a/sigma/pipelines/panther/crowdstrike_panther_pipeline.py
+++ b/sigma/pipelines/panther/crowdstrike_panther_pipeline.py
@@ -14,7 +14,7 @@ from sigma.processing.transformations import (
     ReplaceStringTransformation,
 )
 
-from sigma.pipelines.panther.panther_sdyaml_pipeline import (
+from sigma.pipelines.panther.panther_pipeline import (
     logsource_file_event,
     logsource_linux,
     logsource_mac,

--- a/sigma/pipelines/panther/panther_pipeline.py
+++ b/sigma/pipelines/panther/panther_pipeline.py
@@ -51,7 +51,7 @@ class PipelineWasUsed(RuleProcessingCondition):
         return cli_context and self.pipeline in cli_context.params["pipeline"]
 
 
-def panther_sdyaml_pipeline():
+def panther_pipeline():
     return ProcessingPipeline(
         name="Generic Log Sources to Panther Transformation",
         # Set of identifiers of backends (from the backends mapping) that are allowed to use this processing pipeline.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,13 @@ from sigma.rule import (
 from sigma.types import SigmaNull
 
 from sigma.backends.panther import PantherBackend
-from sigma.pipelines.panther.panther_sdyaml_pipeline import panther_sdyaml_pipeline
+from sigma.pipelines.panther.panther_pipeline import panther_pipeline
 
 
 @pytest.fixture
-def sigma_sdyaml_backend():
-    resolver = ProcessingPipelineResolver({"panther_sdyaml": panther_sdyaml_pipeline})
-    pipeline = resolver.resolve_pipeline("panther_sdyaml")
+def sigma_backend():
+    resolver = ProcessingPipelineResolver({"panther": panther_pipeline})
+    pipeline = resolver.resolve_pipeline("panther")
     backend = PantherBackend(pipeline)
     return backend
 

--- a/tests/test_panther_sdyaml_pipeline.py
+++ b/tests/test_panther_sdyaml_pipeline.py
@@ -4,7 +4,7 @@ import yaml
 from sigma.collection import SigmaCollection
 
 
-def test_basic(sigma_sdyaml_backend):
+def test_basic(sigma_backend):
     rule = SigmaCollection.from_yaml(
         f"""
         title: Test Title
@@ -36,4 +36,4 @@ def test_basic(sigma_sdyaml_backend):
         }
     )
 
-    assert sigma_sdyaml_backend.convert(rule) == expected
+    assert sigma_backend.convert(rule) == expected

--- a/tests/test_replace_condition_ends_with.py
+++ b/tests/test_replace_condition_ends_with.py
@@ -8,7 +8,7 @@ from sigma.pipelines.panther.replace_condition_ends_with import ReplaceCondition
 
 
 class TestReplaceConditionEndsWith:
-    def test_with_one_value(self, pipeline, sigma_sdyaml_backend):
+    def test_with_one_value(self, pipeline, sigma_backend):
         raw_rule = f"""
         title: Test Title
         id: {uuid.uuid4()}
@@ -39,10 +39,10 @@ class TestReplaceConditionEndsWith:
         rule = SigmaRule.from_yaml(raw_rule)
         transformation.apply(pipeline, rule)
 
-        res = sigma_sdyaml_backend.convert(SigmaCollection(rules=[rule]))
+        res = sigma_backend.convert(SigmaCollection(rules=[rule]))
         assert yaml.safe_load(res) == yaml.safe_load(expected)
 
-    def test_with_multiple_values(self, pipeline, sigma_sdyaml_backend):
+    def test_with_multiple_values(self, pipeline, sigma_backend):
         raw_rule = f"""
         title: Test Title
         id: {uuid.uuid4()}
@@ -79,10 +79,10 @@ class TestReplaceConditionEndsWith:
         rule = SigmaRule.from_yaml(raw_rule)
         transformation.apply(pipeline, rule)
 
-        res = sigma_sdyaml_backend.convert(SigmaCollection(rules=[rule]))
+        res = sigma_backend.convert(SigmaCollection(rules=[rule]))
         assert yaml.safe_load(res) == yaml.safe_load(expected)
 
-    def test_with_nested_detections(self, pipeline, sigma_sdyaml_backend):
+    def test_with_nested_detections(self, pipeline, sigma_backend):
         raw_rule = f"""
         title: Test Title
         id: {uuid.uuid4()}
@@ -134,5 +134,5 @@ class TestReplaceConditionEndsWith:
         rule = SigmaRule.from_yaml(raw_rule)
         transformation.apply(pipeline, rule)
 
-        res = sigma_sdyaml_backend.convert(SigmaCollection(rules=[rule]))
+        res = sigma_backend.convert(SigmaCollection(rules=[rule]))
         assert yaml.safe_load(res) == yaml.safe_load(expected)


### PR DESCRIPTION
Rename `panther_sdyaml` pipeline to `panther` as now it is used to convert not only to sdyaml, but to python too