### PR TITLE
Add unified EDR pipeline for Panther UDM

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,26 @@ sigma convert -t panther -f sdyaml path/to/rules -p panther -O output_dir=output
 
 Further, it contains the following processing pipelines in `sigma.pipelines.panther`:
 
-- panther_pipeline: Convert known Sigma field names into their Panther schema equivalent
+- `panther_pipeline`: Convert known Sigma field names into their Panther schema equivalent
+- `unified_sigma_edrs_panther`: Convert Sigma rules to work across multiple EDR platforms (SentinelOne, CrowdStrike, Carbon Black) using `event.udm()` pattern
+  - See [UNIFIED_EDR_PIPELINE.md](./UNIFIED_EDR_PIPELINE.md) for detailed documentation
+- `sentinelone_panther`: Convert Sigma rules for SentinelOne Deep Visibility
+- `crowdstrike_panther`: Convert Sigma rules for CrowdStrike Falcon Data Replicator
+- `carbon_black_panther`: Convert Sigma rules for Carbon Black Endpoint
+
+## Unified EDR Pipeline Usage
+
+Convert Sigma rules to work across SentinelOne, CrowdStrike, and Carbon Black:
+
+```bash
+# Convert a single rule
+sigma convert -t panther -p unified_sigma_edrs_panther -f udm rule.yml
+
+# Convert multiple rules to a directory
+sigma convert -t panther -p unified_sigma_edrs_panther -f udm -O output_dir=rules/ sigma_rules/
+```
+
+The generated rules use `event.udm("FieldName")` to access fields, allowing them to work across all three EDR platforms. See [UNIFIED_EDR_PIPELINE.md](./UNIFIED_EDR_PIPELINE.md) for complete documentation.
 
 ## Local setup for development
 

--- a/sigma/backends/panther/helpers/udm_python_helper.py
+++ b/sigma/backends/panther/helpers/udm_python_helper.py
@@ -44,7 +44,7 @@ class UdmPythonHelper(BasePantherBackendHelper):
         For example: "Image" becomes event.udm("Image", default="")
         """
         # Use event.udm() with the Sigma field name directly
-        key_path_value = f'event.udm("{path}") or ""'
+        key_path_value = f'event.udm("{path}", default="")'
         return key_path_value
 
     def update_parsed_conditions(

--- a/sigma/backends/panther/helpers/udm_python_helper.py
+++ b/sigma/backends/panther/helpers/udm_python_helper.py
@@ -1,0 +1,159 @@
+import re
+from typing import Any, Union
+
+import yaml
+from sigma.conditions import (
+    ConditionAND,
+    ConditionFieldEqualsValueExpression,
+    ConditionOR,
+    ConditionValueExpression,
+    ParentChainMixin,
+)
+from sigma.conversion.state import ConversionState
+
+from sigma.backends.panther.helpers.base import BasePantherBackendHelper
+
+
+def simplify(func):
+    def inner(helper, key_cond_values) -> str:
+        if len(key_cond_values) == 1:
+            result = key_cond_values[0]
+        else:
+            result = func(helper, key_cond_values)
+        return result
+
+    return inner
+
+
+class UdmPythonHelper(BasePantherBackendHelper):
+    """
+    Python helper that uses event.udm() for unified data model field access.
+
+    This helper generates Panther Python rules that use event.udm("SigmaFieldName")
+    instead of direct field access like event.deep_get(), allowing rules to work
+    across multiple EDR platforms (SentinelOne, CrowdStrike, Carbon Black).
+    """
+
+    WILDCARD_SYMBOL = "*"
+
+    @staticmethod
+    def get_key_path_value(path: str):
+        """
+        Generate event.udm() accessor instead of event.deep_get().
+
+        For example: "Image" becomes event.udm("Image") or ""
+        """
+        # Use event.udm() with the Sigma field name directly
+        key_path_value = f'event.udm("{path}") or ""'
+        return key_path_value
+
+    def update_parsed_conditions(
+        self, condition: ParentChainMixin, negated: bool = False
+    ) -> ParentChainMixin:
+        return condition
+
+    def convert_condition_as_in_expression(
+        self, cond: Union[ConditionOR, ConditionAND], state: ConversionState
+    ) -> Any:
+        keys = [x.field for x in cond.args]
+
+        assert len(keys) and len(set(keys)) == 1
+        return f"{self.get_key_path_value(keys[0])} in {[x.value.to_plain() for x in cond.args]}"
+
+    @staticmethod
+    def prepare_cond_value(initial_value: str) -> str:
+        value = initial_value
+        if "\\" in value:
+            value = value.replace("\\", "\\\\")
+        if '"' in value:
+            value = value.replace('"', '\\"')
+        return value
+
+    def convert_condition_field_eq_val_str(
+        self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
+    ) -> Any:
+        key_path = self.get_key_path_value(cond.field)
+        value = str(cond.value)
+        if value == self.WILDCARD_SYMBOL:
+            return f"{key_path} != ''"
+        value = self.prepare_cond_value(value)
+        wildcards_count = value.count(self.WILDCARD_SYMBOL)
+        if wildcards_count == 0:
+            return f'{key_path}.lower() == "{value.lower()}"'
+        if wildcards_count == 1:
+            if value.startswith(self.WILDCARD_SYMBOL):
+                return f'{key_path}.lower().endswith("{value[1:].lower()}")'
+            if value.endswith(self.WILDCARD_SYMBOL):
+                return f'{key_path}.lower().startswith("{value[:-1].lower()}")'
+        if wildcards_count == 2:
+            if value.startswith(self.WILDCARD_SYMBOL) and value.endswith(self.WILDCARD_SYMBOL):
+                return f'"{value[1:-1].lower()}" in {key_path}.lower()'
+        value = value.replace("*", ".*")
+        return f're.match(r"^{value}$", {key_path}, re.IGNORECASE)'
+
+    def convert_condition_field_eq_val_num(
+        self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
+    ) -> Any:
+        # Remove the 'or ""' suffix for numeric comparisons
+        key_path = f'event.udm("{cond.field}")'
+        return f"{key_path} == {cond.value.to_plain()}"
+
+    def convert_condition_field_eq_val_null(
+        self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
+    ) -> Any:
+        key_path = f'event.udm("{cond.field}")'
+        return f"{key_path} is None or {key_path} == ''"
+
+    def convert_condition_field_eq_val_re(
+        self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
+    ) -> Any:
+        key_path = self.get_key_path_value(cond.field)
+        value = str(cond.value.regexp)
+        value = self.prepare_cond_value(value)
+        return f're.match(r"{value}", {key_path}, re.IGNORECASE)'
+
+    def convert_condition_field_eq_val_cidr(
+        self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
+    ) -> Any:
+        key_path = self.get_key_path_value(cond.field)
+        value = cond.value.cidr
+        return f'ipaddress.ip_address({key_path}) in ipaddress.ip_network("{value}")'
+
+    @simplify
+    def convert_condition_or(self, key_cond_values: list) -> Any:
+        return f"any([{', '.join(key_cond_values)}])"
+
+    def simplify_convert_condition_and(self, key_cond_values: list) -> Any:
+        simplified = []
+        for key_cond_value in key_cond_values:
+            if key_cond_value.startswith("all"):
+                simplified.append(key_cond_value[5:-2])  # condition without 'all([' and '])'
+            else:
+                simplified.append(key_cond_value)
+        return simplified
+
+    @simplify
+    def convert_condition_and(self, key_cond_values: list) -> Any:
+        return f"all([{', '.join(key_cond_values)}])"
+
+    def convert_condition_not(self, key_cond_values: list) -> Any:
+        return "not " + ", ".join(key_cond_values)
+
+    def convert_condition_val_str(
+        self, cond: ConditionValueExpression, state: ConversionState
+    ) -> Any:
+        value = self.prepare_cond_value(cond.value.to_plain())
+        return f'"{value}" in json.dumps(event.to_dict())'
+
+    def _add_rule_suffix(self, query, file_name):
+        return file_name
+
+    def write_query_into_file(self, file_path: str, query: Any):
+        detection = query.pop("Detection", "pass")[0]
+        file_path_python = file_path + ".py"
+        file_path_yml = file_path + ".yml"
+        query["Filename"] = file_path_python.split("/")[-1]
+        with open(file_path_python, "w") as file:
+            file.write(detection)
+        with open(file_path_yml, "w") as file:
+            yaml.dump(query, file)

--- a/sigma/backends/panther/helpers/udm_python_helper.py
+++ b/sigma/backends/panther/helpers/udm_python_helper.py
@@ -41,7 +41,7 @@ class UdmPythonHelper(BasePantherBackendHelper):
         """
         Generate event.udm() accessor instead of event.deep_get().
 
-        For example: "Image" becomes event.udm("Image") or ""
+        For example: "Image" becomes event.udm("Image", default="")
         """
         # Use event.udm() with the Sigma field name directly
         key_path_value = f'event.udm("{path}") or ""'

--- a/sigma/backends/panther/panther_backend.py
+++ b/sigma/backends/panther/panther_backend.py
@@ -26,6 +26,7 @@ from sigma.rule import SigmaRule
 from sigma.backends.panther.helpers.pantherflow_helper import PantherFlowHelper
 from sigma.backends.panther.helpers.python_helper import PythonHelper
 from sigma.backends.panther.helpers.sdyaml_helper import SDYAMLHelper
+from sigma.backends.panther.helpers.udm_python_helper import UdmPythonHelper
 from sigma.pipelines.panther import panther_pipeline
 
 
@@ -42,12 +43,14 @@ class PantherBackend(Backend):
         "sdyaml": "sdyaml",
         "python": "python",
         "pantherflow": "pantherflow",
+        "udm": "udm",
     }
     output_format_processing_pipeline = {
         "default": ProcessingPipeline(),
         "sdyaml": ProcessingPipeline(),
         "python": ProcessingPipeline(),
         "pantherflow": ProcessingPipeline(),
+        "udm": ProcessingPipeline(),
     }
 
     format_helpers = {
@@ -55,6 +58,7 @@ class PantherBackend(Backend):
         "sdyaml": SDYAMLHelper(),
         "python": PythonHelper(),
         "pantherflow": PantherFlowHelper(),
+        "udm": UdmPythonHelper(),
     }
 
     convert_or_as_in: ClassVar[bool] = True
@@ -364,6 +368,22 @@ class PantherBackend(Backend):
             return queries[0]
         return queries
 
+    def finalize_output_udm(self, queries):
+        """Finalize output for UDM format (same as sdyaml)"""
+        if self.output_dir:
+            self.save_queries_into_individual_files(queries)
+        # cleanup of SigmaFile key
+        for query in queries:
+            query.pop("SigmaFile", None)
+
+        cli_context = click.get_current_context(silent=True)
+        if cli_context:
+            return "Converted rules are successfully saved"
+
+        if len(queries) == 1:
+            return yaml.dump(queries[0])
+        return yaml.dump(queries)
+
     def finalize_query_default(
         self, rule: SigmaRule, query: Any, index: int, state: ConversionState
     ):
@@ -409,3 +429,32 @@ class PantherBackend(Backend):
  | where {query}
 """
         return query
+
+    def finalize_query_udm(
+        self, rule: SigmaRule, query: Any, index: int, state: ConversionState
+    ):
+        """Finalize query for UDM format - similar to python but with event.udm() calls"""
+        import_ipaddress = "import ipaddress\n" if "ipaddress." in query else ""
+        import_json = "import json\n" if "json." in query else ""
+        import_re = "import re\n" if re.search(r"\bre\.", query) else ""
+        empty_strings = "\n\n" if import_ipaddress or import_json or import_re else ""
+        query = (
+            import_ipaddress
+            + import_json
+            + import_re
+            + empty_strings
+            + f"""def rule(event):
+    if {query}:
+        return True
+    return False
+        """
+        )
+        try:
+            formatted_query = black.format_file_contents(
+                src_contents=query, fast=True, mode=black.FileMode(line_length=100)
+            )
+            return formatted_query
+        except black.parsing.InvalidInput as err:
+            raise SigmaFeatureNotSupportedByBackendError(
+                f"Invalid input for formatting python code: {query}, err {err}"
+            )

--- a/sigma/pipelines/panther/__init__.py
+++ b/sigma/pipelines/panther/__init__.py
@@ -3,6 +3,7 @@ from .crowdstrike_panther_pipeline import crowdstrike_panther_pipeline
 from .panther_pipeline import panther_pipeline
 from .sentinelone_panther_pipeline import sentinelone_panther_pipeline
 from .sysmon_panther_pipeline import sysmon_panther_pipeline
+from .unified_sigma_edrs_panther_pipeline import unified_sigma_edrs_panther_pipeline
 from .windows_panther_pipeline import (
     windows_audit_panther_pipeline,
     windows_logsource_panther_pipeline,

--- a/sigma/pipelines/panther/sdyaml_transformation.py
+++ b/sigma/pipelines/panther/sdyaml_transformation.py
@@ -128,6 +128,14 @@ class SdYamlTransformation(QueryPostprocessingTransformation):
 
         cli_context = click.get_current_context(silent=True)
         if cli_context:
+            if "unified_sigma_edrs_panther" in cli_context.params["pipeline"]:
+                # Unified EDR pipeline - add all three EDR log types
+                log_types.extend([
+                    "SentinelOne.DeepVisibility",
+                    "Crowdstrike.FDREvent",
+                    "CarbonBlack.EndpointEvent",
+                ])
+
             if "crowdstrike_panther" in cli_context.params["pipeline"]:
                 log_types.append("Crowdstrike.FDREvent")
 

--- a/sigma/pipelines/panther/unified_sigma_edrs_panther_pipeline.py
+++ b/sigma/pipelines/panther/unified_sigma_edrs_panther_pipeline.py
@@ -1,0 +1,175 @@
+from sigma.processing.conditions import LogsourceCondition, RuleProcessingItemAppliedCondition
+from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline, QueryPostprocessingItem
+from sigma.processing.transformations import (
+    AddConditionTransformation,
+    ChangeLogsourceTransformation,
+    RuleFailureTransformation,
+)
+
+from sigma.pipelines.panther.sdyaml_transformation import SdYamlTransformation
+
+
+def unified_sigma_edrs_panther_pipeline() -> ProcessingPipeline:
+    """
+    Unified Sigma to Panther pipeline for multiple EDR platforms.
+
+    This pipeline converts Sigma rules to Panther rules using event.udm() for field access,
+    allowing a single rule to work across SentinelOne, CrowdStrike, and Carbon Black EDRs.
+
+    Key differences from platform-specific pipelines:
+    - No field mapping: Sigma fields are kept as-is (e.g., "Image" stays "Image")
+    - Field access uses event.udm("FieldName") instead of direct field access
+    - Works with data models that map Sigma fields to native EDR fields
+    - Generates rules that work across all three EDR platforms
+
+    Supported Sigma field categories:
+    - Process creation fields (Image, CommandLine, User, ProcessId, etc.)
+    - Hash fields (md5, sha1, sha256)
+    - Network fields (DestinationIp, DestinationPort, SourceIp, etc.)
+    - DNS fields (QueryName, query)
+    - File fields (TargetFilename)
+
+    The generated rules should be used with:
+    - SentinelOne.DeepVisibility log type with sentinelone_data_model
+    - Crowdstrike.FDREvent log type with crowdstrike_fdr_data_model
+    - CarbonBlack.EndpointEvent log type with carbonblack_endpoint_data_model
+    """
+
+    # Operating system filters using normalized _os field
+    os_filters = [
+        # Windows OS
+        ProcessingItem(
+            identifier="unified_edr_windows",
+            transformation=AddConditionTransformation({"_os": "windows"}),
+            rule_conditions=[LogsourceCondition(product="windows")],
+        ),
+        # Linux OS
+        ProcessingItem(
+            identifier="unified_edr_linux",
+            transformation=AddConditionTransformation({"_os": "linux"}),
+            rule_conditions=[LogsourceCondition(product="linux")],
+        ),
+        # macOS
+        ProcessingItem(
+            identifier="unified_edr_macos",
+            transformation=AddConditionTransformation({"_os": "macos"}),
+            rule_conditions=[LogsourceCondition(product="macos")],
+        ),
+    ]
+
+    # Event category filters using normalized _event_category field
+    event_category_filters = [
+        # Process creation
+        ProcessingItem(
+            identifier="unified_edr_process_creation",
+            transformation=AddConditionTransformation({"_event_category": "process_creation"}),
+            rule_conditions=[LogsourceCondition(category="process_creation")],
+        ),
+        # File events
+        ProcessingItem(
+            identifier="unified_edr_file_event",
+            transformation=AddConditionTransformation({"_event_category": "file_event"}),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="file_change"),
+                LogsourceCondition(category="file_rename"),
+                LogsourceCondition(category="file_delete"),
+                LogsourceCondition(category="file_event"),
+            ],
+        ),
+        # Image load / Module load
+        ProcessingItem(
+            identifier="unified_edr_image_load",
+            transformation=AddConditionTransformation({"_event_category": "image_load"}),
+            rule_conditions=[LogsourceCondition(category="image_load")],
+        ),
+        # Pipe creation
+        ProcessingItem(
+            identifier="unified_edr_pipe_creation",
+            transformation=AddConditionTransformation({"_event_category": "pipe_creation"}),
+            rule_conditions=[LogsourceCondition(category="pipe_creation")],
+        ),
+        # Registry events
+        ProcessingItem(
+            identifier="unified_edr_registry",
+            transformation=AddConditionTransformation({"_event_category": "registry_event"}),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="registry_add"),
+                LogsourceCondition(category="registry_delete"),
+                LogsourceCondition(category="registry_event"),
+                LogsourceCondition(category="registry_set"),
+            ],
+        ),
+        # DNS queries
+        ProcessingItem(
+            identifier="unified_edr_dns",
+            transformation=AddConditionTransformation({"_event_category": "dns_query"}),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="dns_query"),
+                LogsourceCondition(category="dns"),
+            ],
+        ),
+        # Network connections
+        ProcessingItem(
+            identifier="unified_edr_network",
+            transformation=AddConditionTransformation({"_event_category": "network_connection"}),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="network_connection"),
+                LogsourceCondition(category="firewall"),
+            ],
+        ),
+    ]
+
+    # Change logsource to unified EDR service
+    change_logsource_info = [
+        ProcessingItem(
+            identifier="unified_edr_logsource",
+            transformation=ChangeLogsourceTransformation(service="unified_edr"),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="process_creation"),
+                LogsourceCondition(category="file_change"),
+                LogsourceCondition(category="file_rename"),
+                LogsourceCondition(category="file_delete"),
+                LogsourceCondition(category="file_event"),
+                LogsourceCondition(category="image_load"),
+                LogsourceCondition(category="pipe_creation"),
+                LogsourceCondition(category="registry_add"),
+                LogsourceCondition(category="registry_delete"),
+                LogsourceCondition(category="registry_event"),
+                LogsourceCondition(category="registry_set"),
+                LogsourceCondition(category="dns"),
+                LogsourceCondition(category="dns_query"),
+                LogsourceCondition(category="network_connection"),
+                LogsourceCondition(category="firewall"),
+            ],
+        ),
+    ]
+
+    # Fail on unsupported rule types
+    unsupported_rule_types = [
+        ProcessingItem(
+            identifier="unified_edr_fail_rule_not_supported",
+            rule_condition_linking=any,
+            transformation=RuleFailureTransformation(
+                "Rule type not supported by the Unified Sigma EDR pipeline"
+            ),
+            rule_condition_negation=True,
+            rule_conditions=[RuleProcessingItemAppliedCondition("unified_edr_logsource")],
+        )
+    ]
+
+    return ProcessingPipeline(
+        name="Unified Sigma EDR Panther Pipeline",
+        priority=10,
+        items=[
+            *os_filters,
+            *event_category_filters,
+            *change_logsource_info,
+            *unsupported_rule_types,
+        ],
+        postprocessing_items=[QueryPostprocessingItem(transformation=SdYamlTransformation())],
+    )


### PR DESCRIPTION
## Summary

Adds a unified Sigma-to-Panther pipeline that generates rules compatible with multiple EDR platforms (SentinelOne, CrowdStrike, Carbon Black) using UDM field access.

**Key changes:**
- New `unified_sigma_edrs_panther_pipeline()` that preserves Sigma field names and uses `event.udm()` for field access
- UDM Python helper for generating field accessors with parent field support
- Backend updates to support unified pipeline code generation
- Support for process creation, file events, network, DNS, registry, and other event categories

This enables a single Sigma rule to work across all three EDR platforms when used with the appropriate data models.

Related: panther-labs/panther-analysis#1842