### PR TITLE
Publish Workflow Fix

### DIFF
--- a/.github/workflows/test_release_publish.yml
+++ b/.github/workflows/test_release_publish.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   publish_github_release_and_pypi:
+    permissions:
+      contents: write
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ]
@@ -27,15 +29,18 @@ jobs:
       - name: Build packages
         run: poetry build
       - name: Create Github Release
+        if: matrix.python-version == '3.12'
         run: |
-          export NEW_VERSION=$(cat VERSION)
+          export NEW_VERSION=$(poetry version --short)
           git config user.name "dac-bot"
           git config user.email "dac-bot@panther.com"
           gh release create v$NEW_VERSION dist/* -t v$NEW_VERSION --draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure Poetry
+        if: matrix.python-version == '3.12'
         run: |
             poetry config pypi-token.pypi "${{ secrets.PYPI_API_TOKEN }}"
       - name: Publish to PyPI
+        if: matrix.python-version == '3.12'
         run: poetry publish


### PR DESCRIPTION
  1. Adds permissions: contents: write so GITHUB_TOKEN can create GitHub releases (was failing with 403)                 
  2. Replaces cat VERSION with poetry version --short since no VERSION file exists in the repo                           
  3. Gates the release and PyPI publish steps to only run on Python 3.12 to prevent them from running 3 times across the matrix      